### PR TITLE
Just properly expands other monads

### DIFF
--- a/lib/danom/just.rb
+++ b/lib/danom/just.rb
@@ -1,4 +1,5 @@
 require 'danom/monad'
+require 'byebug'
 
 module Danom
   # Useful for immediately failing when a nil pops up.
@@ -17,6 +18,13 @@ module Danom
     def initialize(value)
       raise CannotBeNil if value == nil
       super
+    end
+
+    # @raise [Danom::Just::CannotBeNil]
+    def monad_value
+      val = super
+      raise CannotBeNil if val == nil
+      val
     end
 
     # Similar to Maybe#and_then but raises an error if the value ever becomes

--- a/lib/danom/monad.rb
+++ b/lib/danom/monad.rb
@@ -42,7 +42,13 @@ module Danom
         @value
       end
     end
-    alias_method :~@, :monad_value
+
+    # Alias for #monad_value
+    #
+    # @see #monad_value
+    def ~@
+      monad_value
+    end
 
 
     # Calls #to_s on the underlying value.

--- a/spec/danom/just_spec.rb
+++ b/spec/danom/just_spec.rb
@@ -18,4 +18,14 @@ describe Danom::Just do
   it 'will raise CannotBeNil if it chains into a nil' do
     expect {  Just({})[:occupation] }.to raise_error(Danom::Just::CannotBeNil)
   end
+
+  it 'can be comined with other monads' do
+    expect { ~Just(Maybe(nil)) }.to raise_error(Danom::Just::CannotBeNil)
+  end
+
+  it 'can be combined with other monads and return their value' do
+    val = 5
+
+    expect(~Just(Maybe(val))).to eq val
+  end
 end


### PR DESCRIPTION
Can now do

```
~Just(Maybe(nil))
```

And it will properly raise an error.