### PR TITLE
All Object methods are now being passed through to a Monad

### DIFF
--- a/lib/danom/just.rb
+++ b/lib/danom/just.rb
@@ -15,7 +15,7 @@ module Danom
 
     # @raise [Danom::Just::CannotBeNil] if value is provided as nil
     def initialize(value)
-      raise CannotBeNil if value == nil
+      raise CannotBeNil if !(Monad === value) && value == nil
       super
     end
 

--- a/lib/danom/monad.rb
+++ b/lib/danom/monad.rb
@@ -51,14 +51,14 @@ module Danom
     end
 
 
-    # Calls #to_s on the underlying value.
+    # Proxy all Object methods to underlying value
     #
-    # @note This happens because method_missing does not override #to_s
     # @private
-    def to_s
-      and_then { |v| v.to_s }
+    Object.new.methods.each do |object_method|
+      define_method object_method do |*args|
+        and_then { |v| v.public_send(object_method, *args) }
+      end
     end
-
 
     private
 


### PR DESCRIPTION
Previously this was only accounted for #to_s but now a Monad will
implement all of Object's methods and try to proxy them to the
underlying value.

Previously the following needed to be done for comparison:

```
~Maybe('str') == 'str' #=> true
Maybe('str') == 'str' #=> false
```

Now `==` and other methods will return a Monad:

```
~Maybe('str') == 'str' #=> true
Maybe('str') == 'str' #=> Danom::Maybe
```